### PR TITLE
Gives His Grace stamina regeneration

### DIFF
--- a/code/game/objects/items/his_grace.dm
+++ b/code/game/objects/items/his_grace.dm
@@ -93,6 +93,7 @@
 				master.remove_status_effect(STATUS_EFFECT_HISGRACE)
 				REMOVE_TRAIT(src, TRAIT_NODROP, HIS_GRACE_TRAIT)
 				master.Knockdown(60)
+				master.adjustStaminaLoss(-5)
 				master.adjustBruteLoss(master.maxHealth)
 				playsound(master, 'sound/effects/splat.ogg', 100, 0)
 			else


### PR DESCRIPTION
His Grace, the 20TC item, is meant to absorb stun damage. When it feeds on corpses, its hunger increases quickly and steadily, but the current stamina system makes it impossible to actually fight without stam-critting yourself and getting eaten.

This gives regeneration to where you can actually use His Grace in the later stages without suffering from exhaustion.
